### PR TITLE
Fix invalid license in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -5,7 +5,7 @@
   "provides": {
     "Ed25519": "lib/Ed25519.rakumod"
   },
-  "license": "MIT-License",
+  "license": "MIT",
   "authors": [ "Lucien Grondin" ],
   "depends": [ "Digest" ],
   "test-depends": [ "JSON::Tiny" ],


### PR DESCRIPTION
The license field should be a valid SPDX identifier as mentioned under https://docs.raku.org/language/modules#Preparing_the_module

The MIT License SPDX identifier is just MIT - https://spdx.org/licenses/MIT.html