### PR TITLE
verify documentation

### DIFF
--- a/sparrow.yaml
+++ b/sparrow.yaml
@@ -20,7 +20,14 @@ tasks:
     depends:
       -
         name: multi-versions
-  -
+    followup:
+      -
+        name: good-doc
+        plugin: good-doc
+        config:
+          path: source/README.md
+          rakudo_path: {{ CWD }}/rakudo-moar-2022.12-01-linux-x86_64-gcc
+-
     name: multi-versions
     language: Raku
     config:

--- a/sparrow.yaml
+++ b/sparrow.yaml
@@ -23,11 +23,13 @@ tasks:
     followup:
       -
         name: good-doc
-        plugin: good-doc
-        config:
-          path: source/README.md
-          rakudo_path: {{ CWD }}/rakudo-moar-2022.12-01-linux-x86_64-gcc
--
+  -
+    name: good-doc
+    plugin: good-doc
+    config:
+      path: source/README.md
+      rakudo_path: "{{ CWD }}/rakudo-moar-2022.12-01-linux-x86_64-gcc"
+  -
     name: multi-versions
     language: Raku
     config:


### PR DESCRIPTION
this patch verifies documentation example (#1) , if any errors occurs during verification _only_ warning is produced, the overall build is still consider good if unit tests pass:

```
Build finished. [ci.sparrowhub.io/report/2357](https://ci.sparrowhub.io/report/2357) | [github.com/melezhik/elliptic-curves-raku.git](https://github.com/melezhik/elliptic-curves-raku.git) | use macros @ 804e9c5 | OK | 1 warnings
```

![warning](https://raw.githubusercontent.com/melezhik/images/master/5750035E-6D60-4C67-BC81-119163D1A9E5.jpeg)

I am not sure if you need this? 